### PR TITLE
Allow loading the mod when using Xaero Minimap Fairplay

### DIFF
--- a/src/main/java/xaeroplus/XaeroPlus.java
+++ b/src/main/java/xaeroplus/XaeroPlus.java
@@ -42,7 +42,7 @@ public class XaeroPlus implements ClientModInitializer {
 	private static void minimapCompatibleVersionCheck() {
 		try {
 			SemanticVersion compatibleMinimapVersion = SemanticVersion.parse(getCompatibleMinimapVersion());
-			if (!checkVersion("xaerominimap", compatibleMinimapVersion) && !checkVersion("xaerobetterpvp", compatibleMinimapVersion)) {
+			if (!checkVersion("xaerominimap", compatibleMinimapVersion) && !checkVersion("xaerobetterpvp", compatibleMinimapVersion) && !checkVersion("xaerominimapfair", compatibleMinimapVersion)) {
 				throw new RuntimeException("XaeroPlus requires version: '" + compatibleMinimapVersion + "' of Xaero's Minimap or BetterPVP installed");
 			}
 		} catch (VersionParsingException e) {


### PR DESCRIPTION
When using the mod with Xaero Minimap Fair-play version the game would crash as the fair-play version has a different mod id