### PR TITLE
Add end gateway blocks to portal highlights module.

### DIFF
--- a/common/src/main/java/xaeroplus/module/impl/Portals.java
+++ b/common/src/main/java/xaeroplus/module/impl/Portals.java
@@ -130,8 +130,9 @@ public class Portals extends Module {
 
     private static final ReferenceSet<Block> PORTAL_BLOCKS = new ReferenceOpenHashSet<>();
     static {
-        PORTAL_BLOCKS.add(Blocks.NETHER_PORTAL);
         PORTAL_BLOCKS.add(Blocks.END_PORTAL);
+        PORTAL_BLOCKS.add(Blocks.END_GATEWAY);
+        PORTAL_BLOCKS.add(Blocks.NETHER_PORTAL);
         PORTAL_BLOCKS.add(Blocks.END_PORTAL_FRAME);
     }
 


### PR DESCRIPTION
When exploring or hunting in the end dimension it can be very helpful to have a visual record of where end gateways are, in case you need to make a quick return to spawn, or for keeping track of interesting features (such as clusters of close-together gateways, or trails that terminate at a gateway).

The database and portals module code already supports highlights in the end dimension, so all that was needed in this case was to add the end gateway block to the PORTAL_BLOCKS set.