### PR TITLE
Fix 'FabricWaystonesHelper.subcribeWaystonesEventsRunnable is null' during initialization

### DIFF
--- a/fabric/src/main/java/xaeroplus/fabric/XaeroPlusFabric.java
+++ b/fabric/src/main/java/xaeroplus/fabric/XaeroPlusFabric.java
@@ -30,9 +30,9 @@ public class XaeroPlusFabric implements ClientModInitializer {
 									   versionCheckResult.anyPresentMinimapVersion().map(Version::getFriendlyString).orElse("None!"));
 				return;
 			}
+			FabricWaystonesHelperInit.doInit();
 			XaeroPlus.initializeSettings();
 			Settings.REGISTRY.getKeybindings().forEach(KeyBindingHelper::registerKeyBinding);
-            FabricWaystonesHelperInit.doInit();
 			if (System.getenv("XP_CI_TEST") != null)
 				Minecraft.getInstance().execute(XaeroPlusGameTest::applyMixinsTest);
         }


### PR DESCRIPTION
This error also appears in other Minecraft versions.

### Stacktrace
```
[16:26:41] [Render thread/ERROR]: Error enabling module: WaystoneSync
java.lang.NullPointerException: Cannot invoke "java.lang.Runnable.run()" because "xaeroplus.util.FabricWaystonesHelper.subcribeWaystonesEventsRunnable" is null
at xaeroplus.module.impl.WaystoneSync.onEnable(WaystoneSync.java:42) ~[XaeroPlus-2.24.5+fabric-1.20.1-WM1.39.0-MM24.6.1.jar:?]
at xaeroplus.module.Module.enable(Module.java:35) ~[XaeroPlus-2.24.5+fabric-1.20.1-WM1.39.0-MM24.6.1.jar:?]
at xaeroplus.module.Module.setEnabled(Module.java:24) ~[XaeroPlus-2.24.5+fabric-1.20.1-WM1.39.0-MM24.6.1.jar:?]
at xaeroplus.settings.Settings.lambda$new$3(Settings.java:90) ~[XaeroPlus-2.24.5+fabric-1.20.1-WM1.39.0-MM24.6.1.jar:?]
at xaeroplus.settings.BooleanSetting.init(BooleanSetting.java:141) ~[XaeroPlus-2.24.5+fabric-1.20.1-WM1.39.0-MM24.6.1.jar:?]
at java.util.ArrayList.forEach(Unknown Source) ~[?:?]
at xaeroplus.XaeroPlus.initializeSettings(XaeroPlus.java:24) ~[XaeroPlus-2.24.5+fabric-1.20.1-WM1.39.0-MM24.6.1.jar:?]
at xaeroplus.fabric.XaeroPlusFabric.initialize(XaeroPlusFabric.java:33) ~[XaeroPlus-2.24.5+fabric-1.20.1-WM1.39.0-MM24.6.1.jar:?]
at xaero.minimap.XaeroMinimap.handler$bcl000$xaeroplus$loadCommonInject(XaeroMinimap.java:517) ~[Xaeros_Minimap_24.6.1_Fabric_1.20.jar:?]
at xaero.minimap.XaeroMinimap.loadCommon(XaeroMinimap.java) ~[Xaeros_Minimap_24.6.1_Fabric_1.20.jar:?]
at xaero.minimap.XaeroMinimapFabric.loadCommon(XaeroMinimapFabric.java:51) ~[Xaeros_Minimap_24.6.1_Fabric_1.20.jar:?]
at xaero.minimap.XaeroMinimapFabric.onInitializeClient(XaeroMinimapFabric.java:26) ~[Xaeros_Minimap_24.6.1_Fabric_1.20.jar:?]
at net.fabricmc.loader.impl.FabricLoaderImpl.invokeEntrypoints(FabricLoaderImpl.java:399) ~[fabric-loader-0.16.9.jar:?]
at net.fabricmc.loader.impl.game.minecraft.Hooks.startClient(Hooks.java:53) ~[fabric-loader-0.16.9.jar:?]
at net.minecraft.class_310.<init>(class_310.java:458) ~[client-intermediary.jar:?]
at net.minecraft.client.main.Main.main(Main.java:211) ~[1.20.1-0.16.9.jar:?]
at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:480) ~[fabric-loader-0.16.9.jar:?]
at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74) ~[fabric-loader-0.16.9.jar:?]
at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23) ~[fabric-loader-0.16.9.jar:?]
```