### PR TITLE
added lava column check for inverse chunk classification in nether

### DIFF
--- a/common/src/main/java/xaeroplus/module/impl/LiquidNewChunks.java
+++ b/common/src/main/java/xaeroplus/module/impl/LiquidNewChunks.java
@@ -156,7 +156,6 @@ public class LiquidNewChunks extends Module {
                     }
                 }
             }
-
             return false;
         }, Settings.REGISTRY.liquidNewChunksOnlyAboveY0Setting.get()
             ? Math.max(1, level.getMinBuildHeight())

--- a/common/src/main/java/xaeroplus/module/impl/LiquidNewChunks.java
+++ b/common/src/main/java/xaeroplus/module/impl/LiquidNewChunks.java
@@ -35,17 +35,17 @@ public class LiquidNewChunks extends Module {
     // chunks where liquid was already flowing or flowed when we loaded it
     public final SavableHighlightCacheInstance inverseNewChunksCache = new SavableHighlightCacheInstance("XaeroPlusNewChunksLiquidInverse");
     private final Cache<Long, Byte> seenChunksCache = Caffeine.newBuilder()
-        .maximumSize(1000)
-        .executor(Globals.cacheRefreshExecutorService.get())
-        .expireAfterAccess(Duration.ofMinutes(5))
-        .build();
+            .maximumSize(1000)
+            .executor(Globals.cacheRefreshExecutorService.get())
+            .expireAfterAccess(Duration.ofMinutes(5))
+            .build();
     private boolean renderInverse = false;
     private int newChunksColor = getColor(255, 0, 0, 100);
     private int inverseColor = getColor(0, 255, 0, 100);
     private static final Direction[] searchDirs = new Direction[] { Direction.EAST, Direction.NORTH, Direction.WEST, Direction.SOUTH, Direction.UP };
     private static final ReferenceSet<Block> liquidBlockTypeFilter = ReferenceOpenHashSet.of(
-        Blocks.WATER,
-        Blocks.LAVA
+            Blocks.WATER,
+            Blocks.LAVA
     );
     private static final String inverseDrawFeatureId = "LiquidNewChunksInverse";
 
@@ -133,10 +133,34 @@ public class LiquidNewChunks extends Module {
                     return true;
                 }
             }
+            // added this conditional block for nether specific inverse logic that wouldn't trigger under the default logic above
+            if (mc.level.dimension().location().toString().toLowerCase().contains("nether")) {
+                if (state.getBlock() == Blocks.LAVA) {
+                    int columnHeight = 1;
+                    // check columns ≥16 blocks
+                    for (int i = 1; i <= 16; i++) {
+                        var aboveFluid = chunk.getFluidState(
+                                ChunkUtils.chunkCoordToCoord(c.getPos().x) + relX,
+                                y + i,
+                                ChunkUtils.chunkCoordToCoord(c.getPos().z) + relZ
+                        );
+                        if (!aboveFluid.isEmpty() && !aboveFluid.isSource()) {
+                            columnHeight++;
+                        } else {
+                            break;
+                        }
+                    }
+                    if (columnHeight >= 12) {
+                        inverseNewChunksCache.get().addHighlight(c.getPos().x, c.getPos().z);
+                        return true;
+                    }
+                }
+            }
+
             return false;
         }, Settings.REGISTRY.liquidNewChunksOnlyAboveY0Setting.get()
-            ? Math.max(1, level.getMinBuildHeight())
-            : level.getMinBuildHeight());
+                ? Math.max(1, level.getMinBuildHeight())
+                : level.getMinBuildHeight());
     }
 
     @EventHandler
@@ -156,12 +180,12 @@ public class LiquidNewChunks extends Module {
     @Override
     public void onEnable() {
         Globals.drawManager.registry().register(
-            DrawFeatureFactory.chunkHighlights(
-                this.getClass().getName(),
-                this::getNewChunkHighlightsState,
-                this::getNewChunksColor,
-                250
-            )
+                DrawFeatureFactory.chunkHighlights(
+                        this.getClass().getName(),
+                        this::getNewChunkHighlightsState,
+                        this::getNewChunksColor,
+                        250
+                )
         );
         if (renderInverse) {
             registerInverseChunkHighlightProvider();
@@ -172,12 +196,12 @@ public class LiquidNewChunks extends Module {
 
     private void registerInverseChunkHighlightProvider() {
         Globals.drawManager.registry().register(
-            DrawFeatureFactory.chunkHighlights(
-                inverseDrawFeatureId,
-                this::getInverseNewChunkHighlightsState,
-                this::getInverseColor,
-                250
-            )
+                DrawFeatureFactory.chunkHighlights(
+                        inverseDrawFeatureId,
+                        this::getInverseNewChunkHighlightsState,
+                        this::getInverseColor,
+                        250
+                )
         );
     }
 

--- a/common/src/main/java/xaeroplus/module/impl/LiquidNewChunks.java
+++ b/common/src/main/java/xaeroplus/module/impl/LiquidNewChunks.java
@@ -136,29 +136,6 @@ public class LiquidNewChunks extends Module {
                     return true;
                 }
             }
-            // added this conditional block for nether specific inverse logic that wouldn't trigger under the default logic above
-            if (mc.level.dimension().location().toString().toLowerCase().contains("nether")) {
-                if (state.getBlock() == Blocks.LAVA) {
-                    int columnHeight = 1;
-                    // check columns ≥16 blocks
-                    for (int i = 1; i <= 16; i++) {
-                        var aboveFluid = chunk.getFluidState(
-                                ChunkUtils.chunkCoordToCoord(c.getPos().x) + relX,
-                                y + i,
-                                ChunkUtils.chunkCoordToCoord(c.getPos().z) + relZ
-                        );
-                        if (!aboveFluid.isEmpty() && !aboveFluid.isSource()) {
-                            columnHeight++;
-                        } else {
-                            break;
-                        }
-                    }
-                    if (columnHeight >= 12) {
-                        inverseNewChunksCache.get().addHighlight(c.getPos().x, c.getPos().z);
-                        return true;
-                    }
-                }
-            }
             return false;
         }, Settings.REGISTRY.liquidNewChunksOnlyAboveY0Setting.get()
             ? Math.max(1, level.getMinBuildHeight())

--- a/common/src/main/java/xaeroplus/module/impl/LiquidNewChunks.java
+++ b/common/src/main/java/xaeroplus/module/impl/LiquidNewChunks.java
@@ -160,10 +160,9 @@ public class LiquidNewChunks extends Module {
 
             return false;
         }, Settings.REGISTRY.liquidNewChunksOnlyAboveY0Setting.get()
-                ? Math.max(1, level.getMinBuildHeight())
-                : level.getMinBuildHeight());
+            ? Math.max(1, level.getMinBuildHeight())
+            : level.getMinBuildHeight());
     }
-
 
     @EventHandler
     public void onXaeroWorldChangeEvent(final XaeroWorldChangeEvent event) {

--- a/common/src/main/java/xaeroplus/module/impl/LiquidNewChunks.java
+++ b/common/src/main/java/xaeroplus/module/impl/LiquidNewChunks.java
@@ -35,17 +35,17 @@ public class LiquidNewChunks extends Module {
     // chunks where liquid was already flowing or flowed when we loaded it
     public final SavableHighlightCacheInstance inverseNewChunksCache = new SavableHighlightCacheInstance("XaeroPlusNewChunksLiquidInverse");
     private final Cache<Long, Byte> seenChunksCache = Caffeine.newBuilder()
-            .maximumSize(1000)
-            .executor(Globals.cacheRefreshExecutorService.get())
-            .expireAfterAccess(Duration.ofMinutes(5))
-            .build();
+        .maximumSize(1000)
+        .executor(Globals.cacheRefreshExecutorService.get())
+        .expireAfterAccess(Duration.ofMinutes(5))
+        .build();
     private boolean renderInverse = false;
     private int newChunksColor = getColor(255, 0, 0, 100);
     private int inverseColor = getColor(0, 255, 0, 100);
     private static final Direction[] searchDirs = new Direction[] { Direction.EAST, Direction.NORTH, Direction.WEST, Direction.SOUTH, Direction.UP };
     private static final ReferenceSet<Block> liquidBlockTypeFilter = ReferenceOpenHashSet.of(
-            Blocks.WATER,
-            Blocks.LAVA
+        Blocks.WATER,
+        Blocks.LAVA
     );
     private static final String inverseDrawFeatureId = "LiquidNewChunksInverse";
 
@@ -133,6 +133,7 @@ public class LiquidNewChunks extends Module {
                     return true;
                 }
             }
+
             // added this conditional block for nether specific inverse logic that wouldn't trigger under the default logic above
             if (mc.level.dimension().location().toString().toLowerCase().contains("nether")) {
                 if (state.getBlock() == Blocks.LAVA) {
@@ -163,6 +164,7 @@ public class LiquidNewChunks extends Module {
                 : level.getMinBuildHeight());
     }
 
+
     @EventHandler
     public void onXaeroWorldChangeEvent(final XaeroWorldChangeEvent event) {
         seenChunksCache.invalidateAll(); // side effect - switching dimensions resets our state
@@ -180,12 +182,12 @@ public class LiquidNewChunks extends Module {
     @Override
     public void onEnable() {
         Globals.drawManager.registry().register(
-                DrawFeatureFactory.chunkHighlights(
-                        this.getClass().getName(),
-                        this::getNewChunkHighlightsState,
-                        this::getNewChunksColor,
-                        250
-                )
+            DrawFeatureFactory.chunkHighlights(
+                this.getClass().getName(),
+                this::getNewChunkHighlightsState,
+                this::getNewChunksColor,
+                250
+            )
         );
         if (renderInverse) {
             registerInverseChunkHighlightProvider();
@@ -196,12 +198,12 @@ public class LiquidNewChunks extends Module {
 
     private void registerInverseChunkHighlightProvider() {
         Globals.drawManager.registry().register(
-                DrawFeatureFactory.chunkHighlights(
-                        inverseDrawFeatureId,
-                        this::getInverseNewChunkHighlightsState,
-                        this::getInverseColor,
-                        250
-                )
+            DrawFeatureFactory.chunkHighlights(
+                inverseDrawFeatureId,
+                this::getInverseNewChunkHighlightsState,
+                this::getInverseColor,
+                250
+            )
         );
     }
 

--- a/common/src/main/java/xaeroplus/module/impl/LiquidNewChunks.java
+++ b/common/src/main/java/xaeroplus/module/impl/LiquidNewChunks.java
@@ -116,9 +116,7 @@ public class LiquidNewChunks extends Module {
 
             var fluid = state.getFluidState();
             if (!fluid.isEmpty() && !fluid.isSource()) {
-                // remove check for single lava source blocks in nether (my only change to core logic, sorry! only for nether.)
-                boolean isInNether = mc.level.dimension().location().toString().toLowerCase().contains("nether");
-                if ((fluid.getAmount() < 2 && !isInNether) || (isInNether && fluid.getAmount() < 1)) {
+                if (fluid.getAmount() < 2) {
                     inverseNewChunksCache.get().addHighlight(c.getPos().x, chunk.getPos().z);
                     return true;
                 }

--- a/common/src/main/java/xaeroplus/module/impl/LiquidNewChunks.java
+++ b/common/src/main/java/xaeroplus/module/impl/LiquidNewChunks.java
@@ -133,7 +133,6 @@ public class LiquidNewChunks extends Module {
                     return true;
                 }
             }
-
             // added this conditional block for nether specific inverse logic that wouldn't trigger under the default logic above
             if (mc.level.dimension().location().toString().toLowerCase().contains("nether")) {
                 if (state.getBlock() == Blocks.LAVA) {

--- a/common/src/main/java/xaeroplus/module/impl/LiquidNewChunks.java
+++ b/common/src/main/java/xaeroplus/module/impl/LiquidNewChunks.java
@@ -116,12 +116,15 @@ public class LiquidNewChunks extends Module {
 
             var fluid = state.getFluidState();
             if (!fluid.isEmpty() && !fluid.isSource()) {
-                if (fluid.getAmount() < 2) {
+                // remove check for single lava source blocks in nether (my only change to core logic, sorry! only for nether.)
+                boolean isInNether = mc.level.dimension().location().toString().toLowerCase().contains("nether");
+                if ((fluid.getAmount() < 2 && !isInNether) || (isInNether && fluid.getAmount() < 1)) {
                     inverseNewChunksCache.get().addHighlight(c.getPos().x, chunk.getPos().z);
                     return true;
                 }
                 boolean foundColumn = true;
-                for (int i = 1; i <= 5; i++) {
+                int threshold = this.inverseThreshold;
+                for (int i = 1; i <= threshold; i++) {
                     var aboveState = chunk.getFluidState(x, y + i, z);
                     if (aboveState.isEmpty() || aboveState.isSource()) {
                         foundColumn = false;
@@ -195,6 +198,12 @@ public class LiquidNewChunks extends Module {
 
     private int getInverseColor() {
         return this.inverseColor;
+    }
+
+    private int inverseThreshold = 5;
+
+    public void setInverseThreshold(int threshold) {
+        this.inverseThreshold = threshold;
     }
 
     public void setRgbColor(final int color) {

--- a/common/src/main/java/xaeroplus/settings/Settings.java
+++ b/common/src/main/java/xaeroplus/settings/Settings.java
@@ -481,6 +481,15 @@ public final class Settings extends SettingRegistry {
             (b) -> ModuleManager.getModule(LiquidNewChunks.class).setInverseRgbColor(b.getColor()),
             () -> ModuleManager.getModule(LiquidNewChunks.class).isEnabled()),
         SettingLocation.CHUNK_HIGHLIGHTS);
+    public final DoubleSetting liquidNewChunksInverseThresholdSetting = register(
+        DoubleSetting.create(
+            "New Chunks Inverse Threshold",
+            "xaeroplus.setting.liquidNewChunksInverseThreshold",
+            3, 20, 1,
+            5,
+            (val) -> ModuleManager.getModule(LiquidNewChunks.class).setInverseThreshold((int) val),
+            () -> ModuleManager.getModule(LiquidNewChunks.class).isEnabled()),
+        SettingLocation.CHUNK_HIGHLIGHTS);
     public final BooleanSetting liquidNewChunksOnlyAboveY0Setting = register(
         BooleanSetting.create(
             "Liquid NewChunks Only Y > 0",

--- a/common/src/main/resources/assets/xaeroplus/lang/en_us.json
+++ b/common/src/main/resources/assets/xaeroplus/lang/en_us.json
@@ -63,6 +63,8 @@
   "xaeroplus.setting.new_chunks_inverse_enabled.tooltip": "Highlights chunks that have already been loaded by checking if any flowing liquid is present.\n\nKeep in mind there will be false positives. Multiple biomes and structures like bastions and basalt deltas can generate with flowing liquid.",
   "xaeroplus.setting.new_chunks_inverse_color": "Liquid NewChunks Inverse Color",
   "xaeroplus.setting.new_chunks_inverse_color.tooltip": "Changes the color of Liquid NewChunks inverse highlights",
+  "xaeroplus.setting.liquidNewChunksInverseThreshold": "Liquid NewChunks Inverse",
+  "xaeroplus.setting.liquidNewChunksInverseThreshold.tooltip": "Sets the inverse search threshold for detecting flowing liquid columns. Higher values reduce false positives but may miss valid inverse chunks.",
   "xaeroplus.setting.new_chunks_only_above_y0": "Liquid NewChunks Only Y > 0",
   "xaeroplus.setting.new_chunks_only_above_y0.tooltip": "Limits Liquid NewChunks search to Y levels greater than 0",
   "xaeroplus.setting.old_chunks_highlighting": "OldChunks",


### PR DESCRIPTION
added a conditional to add lava columns to the inverseNewChunksCache, supplements the default logic to add more inverse highlights for possible portal skips in the nether