### PR TITLE
[codex] Fix 1.21 minimap version resolution

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,8 @@ parchment_version=2024.11.17
 
 worldmap_version_fabric=1.40.11
 
-minimap_version_fabric=25.3.10
+minimap_version_fabric=25.3.2
+minimap_version_fabric_maven=25.3.2_Fabric_1.21
 
 worldmap_version_forge=1.40.11
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ plugins {
 val minecraft_version: String by ext.properties
 val worldmap_version_fabric: String by ext.properties
 val minimap_version_fabric: String by ext.properties
+val minimap_version_fabric_maven: String by ext.properties
 val worldmap_version_forge: String by ext.properties
 val minimap_version_forge: String by ext.properties
 val worldmap_version_neo: String by ext.properties
@@ -32,7 +33,7 @@ dependencyResolutionManagement {
             library("worldmap-fabric", "maven.modrinth:xaeros-world-map:fabric-${minecraft_version}-${worldmap_version_fabric}")
             library("worldmap-forge", "maven.modrinth:xaeros-world-map:forge-${minecraft_version}-${worldmap_version_forge}")
             library("worldmap-neo", "maven.modrinth:xaeros-world-map:neoforge-${minecraft_version}-${worldmap_version_neo}")
-            library("minimap-fabric", "maven.modrinth:xaeros-minimap:fabric-${minecraft_version}-${minimap_version_fabric}")
+            library("minimap-fabric", "maven.modrinth:xaeros-minimap:${minimap_version_fabric_maven}")
             library("minimap-forge", "maven.modrinth:xaeros-minimap:forge-${minecraft_version}-${minimap_version_forge}")
             library("minimap-neo", "maven.modrinth:xaeros-minimap:neoforge-${minecraft_version}-${minimap_version_neo}")
             library("xaerolib-fabric", "xaero.lib:xaerolib-fabric-${minecraft_version}:${xaerolib_version}")


### PR DESCRIPTION
## What changed

This updates the Fabric 1.21.1 minimap dependency from `25.3.10` to the actual latest available 1.21 release, `25.3.2`.

It also adds a dedicated Maven version property for the Fabric minimap dependency, because the older 1.21 Modrinth artifact uses the legacy version string `25.3.2_Fabric_1.21` instead of the newer `fabric-<mc>-<version>` naming scheme.

## Why

Issue #296 reports that XaeroPlus 2.30.10 for Minecraft 1.21 requires Xaero's Minimap `25.3.10`, but that version does not exist for 1.21. The latest actual 1.21 minimap release is `25.3.2`, so the current dependency cannot be satisfied.

## Impact

Fabric 1.21.1 builds now resolve the correct minimap artifact and produce jars tagged with `MM25.3.2`, which matches the version users can actually install alongside World Map `1.40.11`.

## Validation

- Ran `./gradlew.bat :fabric:build`
