### PR TITLE
(1.21.5) fix single-color line render params

### DIFF
--- a/common/src/main/java/xaeroplus/feature/render/line/LineVertexBuffer.java
+++ b/common/src/main/java/xaeroplus/feature/render/line/LineVertexBuffer.java
@@ -72,11 +72,12 @@ public class LineVertexBuffer extends AbstractLineVertexBuffer<List<Line>> {
         try (final RenderPass pass = RenderSystem.getDevice().createCommandEncoder()
             .createRenderPass(Minecraft.getInstance().getMainRenderTarget().getColorTexture(), OptionalInt.empty())) {
             pass.setPipeline(XaeroPlusShaders.LINES_PIPELINE);
-            pass.setUniform("MapViewMatrix", ctx.matrixStack().last().pose());
+            pass.setUniform("MapViewMatrix", ctx.untranslatedMapViewMatrix());
             pass.setUniform("ModelViewMat", RenderSystem.getModelViewMatrix());
             pass.setUniform("ProjMat", RenderSystem.getProjectionMatrix());
             pass.setUniform("FrameSize", XaeroPlusShaders.LINES_FRAME_SIZE);
             pass.setUniform("ColorModulator", RenderSystem.getShaderColor());
+            pass.setUniform("CameraRelativeOrigin", (float) ((long) bufferOriginBlockX - ctx.cameraBlockX()), (float) ((long) bufferOriginBlockZ - ctx.cameraBlockZ()));
             pass.setUniform("LineWidth", lineWidthScale);
             pass.setIndexBuffer(indexBuffer, indexType);
             pass.setVertexBuffer(0, vertexBuffer);


### PR DESCRIPTION
fixes highways failing to render past 250k. LineVertexBuffer was missing the CameraRelativeOrigin uniform and used the translated matrix stack instead of untranslatedMapViewMatrix(), pushing the lines way off-screen. updated it to just match how MultiColorLineVertexBuffer sets up its uniforms.

only happens on 1.21.5